### PR TITLE
Bug fix only published tags

### DIFF
--- a/blog/templates/blog/tags.html
+++ b/blog/templates/blog/tags.html
@@ -9,13 +9,13 @@
         
         {% if tag_list %}
             <ul class="tag-list">
-            {% for tag in tag_list %}
-                {% if tag.posts.all.count > 0 %}
+            {% for tag, tag_count in tag_list.items %}
+                {% if tag_count > 0 %}
                 <li class="tag-item">
                     <a href="{% url 'posts_list_by_tag' slug=tag.slug %}">
                         {{tag.title}} 
                         <span class="badge">                        
-                            {{tag.posts.all.count}}                                  
+                            {{tag_count}}                                  
                         </span>
                     </a>
                 </li>

--- a/blog/views.py
+++ b/blog/views.py
@@ -72,7 +72,14 @@ class TagsView(ListView):
     template_name = 'blog/tags.html'
     model = Tag
     context_object_name = 'tag_list'
+
+    def get_queryset(self):
+
+        # set() avoid duplicates from filter
+        published_tags = set(Tag.objects.filter(posts__status="Published"))
+        tags_count = {tag:tag.posts.filter(status="Published").count() for tag in published_tags}
     
+        return tags_count
 
 class PostListByTag(ListView):
 


### PR DESCRIPTION
Na view de Tags, ela tava mostrando todas as tags criadas. Ela só deve mostrar tags que estejam associadas a posts já publicados. Tags que não possuem posts e tags que possuem posts não publicados, não devem aparecer.